### PR TITLE
Use a different EventEmitter

### DIFF
--- a/codemod.md
+++ b/codemod.md
@@ -51,7 +51,7 @@ deno run -A --unstable codemod.ts
 // replace
 import { EventEmitter } from '../events/index.ts';
 // with
-import EventEmitter from 'https://deno.land/x/event_emitter/mod.ts';
+import EventEmitter from 'https://deno.land/x/events@v1.0.0/mod.ts';
 ```
 
 7. Remove all uses and definitions of WritableStream.

--- a/htmlparser2/Parser.ts
+++ b/htmlparser2/Parser.ts
@@ -1,5 +1,5 @@
 import Tokenizer from "./Tokenizer.ts";
-import EventEmitter from "https://deno.land/x/event_emitter/mod.ts";
+import EventEmitter from "https://deno.land/x/events@v1.0.0/mod.ts";
 
 const formTags = new Set([
   "input",


### PR DESCRIPTION
I'm new to Deno, but I'm pretty sure modules in https://deno.land/x aren't supposed to disappear. However, it looks like https://deno.land/x/event_emitter has gone missing. I'm not really sure why or how to find out why.

In this PR, I'm using https://deno.land/x/events@v1.0.0/mod.ts instead. I haven't done extensive testing, but it is working in my project.